### PR TITLE
Stop the menu slide animation when clicking the button multiple times

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -119,7 +119,7 @@ jQuery( document ).ready( function() {
 
 	jQuery( '.menu-toggle button' ).click(
 		function() {
-			jQuery( this ).parents( '.menu' ).children( '.wrap' ).slideToggle( 'slow' ).toggleClass( 'open' );
+			jQuery( this ).parents( '.menu' ).children( '.wrap' ).stop().slideToggle( 'slow' ).toggleClass( 'open' );
 			jQuery( this ).toggleClass( 'active' );
 		}
 	);


### PR DESCRIPTION
Clicking the menu toggle button many times in a row causes a queue build up, where the menu just slides up and down till it's done.

This PR adds `.stop()` before `.slideToggle()`

> "When `.stop()` is called on an element, the currently-running animation (if any) is immediately stopped" - http://api.jquery.com/stop/
