### PR TITLE
use apply_filters instead of get_theme_mod

### DIFF
--- a/inc/custom-colors.php
+++ b/inc/custom-colors.php
@@ -323,7 +323,7 @@ final class Saga_Custom_Colors {
 		$wp_customize->add_setting(
 			'color_menu',
 			array(
-				'default'              => get_theme_mod( 'color_primary', '' ),
+				'default'              => apply_filters( 'theme_mod_color_menu', '' ),
 				'type'                 => 'theme_mod',
 				'capability'           => 'edit_theme_options',
 				'sanitize_callback'    => 'sanitize_hex_color_no_hash',
@@ -336,7 +336,7 @@ final class Saga_Custom_Colors {
 		$wp_customize->add_setting(
 			'color_primary',
 			array(
-				'default'              => get_theme_mod( 'color_menu', '' ),
+				'default'              => apply_filters( 'theme_mod_color_primary', '' ),
 				'type'                 => 'theme_mod',
 				'capability'           => 'edit_theme_options',
 				'sanitize_callback'    => 'sanitize_hex_color_no_hash',


### PR DESCRIPTION
I finally figured out why this wasn't working consistently when I compared it to how Stargazer did it. https://github.com/justintadlock/stargazer/blob/master/inc/custom-colors.php#L229
Also corrected color_menu and color_primary being switched. 
